### PR TITLE
Updating the Python version requirement in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ Uvicorn currently supports HTTP/1.1 and WebSockets. Support for HTTP/2 is planne
 
 ## Quickstart
 
-Requirements: Python 3.5, 3.6, 3.7
+Requirements: Python 3.6+ (For Python 3.5 support, install version 0.8.6.)
 
 Install using `pip`:
 


### PR DESCRIPTION
Since it supports Python 3.8 too, updating the minimum requirement accordingly.
Essentially, copying the same description as mentioned in the README.md.
